### PR TITLE
chore: update `b3lbctl cluster-info` to call new cluster info endpoint #38

### DIFF
--- a/pkg/admin/admin.go
+++ b/pkg/admin/admin.go
@@ -108,7 +108,7 @@ func (a *DefaultAdmin) Delete(instance string) error {
 
 // ClusterStatus call cluster status admin api and return result
 func (a *DefaultAdmin) ClusterStatus() ([]balancer.InstanceStatus, error) {
-	resp, err := restclient.GetWithHeaders(fmt.Sprintf("%s/admin/cluster/status", *config.URL), authorization())
+	resp, err := restclient.GetWithHeaders(fmt.Sprintf("%s/admin/api/cluster", *config.URL), authorization())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
resolve #38 